### PR TITLE
Fix loading error and recod results in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     - Component only renders a set number of data
     - Clicking the "Load More" button will render a set number of additional data on the screen until the limit has been reached
     - ***There is currently an error in the component where the initial data is loaded twice. Functionality works for additional renders, but this error needs to be fixed before project is complete.***
+    - ***Error occurs because React.StrictMode calls the data twice in development mode. Removing Strict More from the index.js file fixes the issue.***
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The fetch error is caused by using React.StrictMode. In development mode, the fetch is initially called twice. Removing (or commenting out) Strict Mode from the index.js file fixes this issue. Because the error *shouldn't* occur in production mode, I did not make any permanent changes to the code.